### PR TITLE
OPS-5169 alter stage set location and refresh ext table

### DIFF
--- a/src/main/java/net/snowflake/hivemetastoreconnector/commands/AlterExternalTable.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/commands/AlterExternalTable.java
@@ -182,7 +182,7 @@ public class AlterExternalTable extends Command
   {
       return ImmutableList.of(
          String.format("ALTER EXTERNAL TABLE IF EXISTS %s REFRESH;",
-             StringUtil.escapeSqlIdentifier(newTable.getTableName())));
+             StringUtil.escapeSqlIdentifier(newHiveTable.getTableName())));
   }
 
   /**

--- a/src/main/java/net/snowflake/hivemetastoreconnector/commands/AlterExternalTable.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/commands/AlterExternalTable.java
@@ -255,7 +255,7 @@ public class AlterExternalTable extends Command
                                                 snowflakeConf));
     }
 
-    if (!Objects.equal(oldTable.getSd().getLocation(), newTable.getSd().getLocation())) {
+    if (!Objects.equal(oldHiveTable.getSd().getLocation(), newHiveTable.getSd().getLocation())) {
       commands.addAll(generateAlterStageSetURLSqlQueries());
       commands.addAll(generateRefreshTableSqlQueries());
     }


### PR DESCRIPTION
Enables https://github.com/tubular/infrastructure/pull/16251

To implement Hive ALTER TABLE .. SET LOCATION we define a stage pointed to a LOCATION, the path under which the warehouse files exist.  The _prev_state table location is updated by creating a tmp table containing the new data, repartitioned, then setting the location in the prod version of _prev_state to the list of files corresponding to the tmp table.  The new partition files are in an entirely new build dir, so the STAGE location has to be updated to point to the new dir.  We can’t just append partitions to the Snowflake table because /all/ the partition files are new.

ALTER the STAGE setting the LOCATION to the list of new files

run ALTER EXTERNAL TABLE .. REFRESH to make the table absorb the new data from the STAGE